### PR TITLE
Real exception

### DIFF
--- a/celery_rpc/base.py
+++ b/celery_rpc/base.py
@@ -31,9 +31,7 @@ class remote_error(object):
         if isinstance(exc_val, RemoteException):
             return
         if exc_val and self.task.app.conf['WRAP_REMOTE_ERRORS']:
-            print exc_type
             serializer = self.task.app.conf['CELERY_RESULT_SERIALIZER']
-            print serializer
             raise RemoteException(exc_val, serializer)
 
 

--- a/celery_rpc/base.py
+++ b/celery_rpc/base.py
@@ -28,8 +28,12 @@ class remote_error(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """ Unpacks exception from RemoteException wrapper, if enabled in
         celery_rpc config."""
+        if isinstance(exc_val, RemoteException):
+            return
         if exc_val and self.task.app.conf['WRAP_REMOTE_ERRORS']:
-            serializer = self.task.app.conf['CELERY_TASK_SERIALIZER']
+            print exc_type
+            serializer = self.task.app.conf['CELERY_RESULT_SERIALIZER']
+            print serializer
             raise RemoteException(exc_val, serializer)
 
 

--- a/celery_rpc/client.py
+++ b/celery_rpc/client.py
@@ -4,6 +4,7 @@ import os
 from celery.exceptions import TimeoutError
 
 from . import utils
+from kombu.serialization import registry
 from .config import GET_RESULT_TIMEOUT
 from .exceptions import RestFrameworkError, remote_exception_registry
 
@@ -279,7 +280,8 @@ class Client(object):
 
     def _unpack_exception(self, error):
         wrap_errors = self._app.conf['WRAP_REMOTE_ERRORS']
-        return utils.unpack_exception(error, wrap_errors)
+        serializer = self._app.conf['CELERY_RESULT_SERIALIZER']
+        return utils.unpack_exception(error, wrap_errors, serializer=serializer)
 
     def pipe(self):
         """ Create pipeline for RPC request

--- a/celery_rpc/config.py
+++ b/celery_rpc/config.py
@@ -11,7 +11,7 @@ except ImportError:
 FILTER_LIMIT = 1000
 
 # Default timeout for getting results
-GET_RESULT_TIMEOUT = 1000
+GET_RESULT_TIMEOUT = 10
 
 # Pass exceptions from server to client as instances if true.
 # By default exceptions are passed as a string.

--- a/celery_rpc/config.py
+++ b/celery_rpc/config.py
@@ -11,7 +11,7 @@ except ImportError:
 FILTER_LIMIT = 1000
 
 # Default timeout for getting results
-GET_RESULT_TIMEOUT = 10
+GET_RESULT_TIMEOUT = 1000
 
 # Pass exceptions from server to client as instances if true.
 # By default exceptions are passed as a string.

--- a/celery_rpc/exceptions.py
+++ b/celery_rpc/exceptions.py
@@ -1,8 +1,8 @@
 # coding: utf-8
-from kombu.exceptions import ContentDisallowed
-
-from kombu.serialization import dumps, loads, registry
 from celery.backends.base import create_exception_cls
+
+from kombu.exceptions import ContentDisallowed
+from kombu.serialization import dumps, loads, registry
 from kombu.utils.encoding import from_utf8
 
 from celery_rpc.utils import symbol_by_name, DEFAULT_EXC_SERIALIZER

--- a/celery_rpc/tests/utils.py
+++ b/celery_rpc/tests/utils.py
@@ -35,7 +35,6 @@ class RemoteException(Exception):
 
 def fail(*args):
     raise ValidationError({"field": "gavno"})
-    raise RemoteException(*args)
 
 
 class unpack_exception(object):

--- a/celery_rpc/utils.py
+++ b/celery_rpc/utils.py
@@ -57,8 +57,10 @@ RESULT_TASK_NAME = 'celery_rpc.result'
 
 TASK_NAME_MAP = {n: v for n, v in locals().items() if n.endswith('_TASK_NAME')}
 
+DEFAULT_EXC_SERIALIZER = 'json'
 
-def unpack_exception(error, wrap_errors):
+
+def unpack_exception(error, wrap_errors, serializer=DEFAULT_EXC_SERIALIZER):
     """ Extracts original error from RemoteException description
     :param error: remote exception stub (or real) instance
     :type error: RemoteException
@@ -78,5 +80,5 @@ def unpack_exception(error, wrap_errors):
         # Stub exception
         from celery_rpc.exceptions import RemoteException
         error = RemoteException(error.args)
-    error = error.unpack_exception()
+    error = error.unpack_exception(serializer)
     return error


### PR DESCRIPTION
Fact is that all arguments from server side are encoded with `str()` call in `celery.backends.base`:
```python
    def prepare_exception(self, exc, serializer=None):
        """Prepare exception for serialization."""
        serializer = self.serializer if serializer is None else serializer
        if serializer in EXCEPTION_ABLE_CODECS:
            return get_pickleable_exception(exc)
        return {'exc_type': type(exc).__name__, 'exc_message': str(exc)}
```
