### PR TITLE
Передача заголовка referer в тасках

### DIFF
--- a/celery_rpc/config.py
+++ b/celery_rpc/config.py
@@ -23,6 +23,9 @@ WRAP_REMOTE_ERRORS = False
 # Do it on your own risk!
 OVERRIDE_BASE_TASKS = {}
 
+# default celery rpc client name which will be passed as referer header
+RPC_CLIENT_NAME = "celery_rpc_client"
+
 # See Celery configuration parameters at
 # http://docs.celeryproject.org/en/latest/configuration.html
 # Some reasonable defaults are defined below

--- a/celery_rpc/tests/test_client.py
+++ b/celery_rpc/tests/test_client.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+
+import socket
 from datetime import datetime
 import mock
 
@@ -120,3 +122,24 @@ class AlterIdentityTests(SimpleModelTestMixin, TestCase):
         r = self.rpc_client.delete(self.MODEL_SYMBOL, self.data, self.kwargs)
         self.assertIsNone(r)
         self.assertFalse(self.MODEL.objects.filter(pk=self.models[0].pk).exists())
+
+
+class SetRefererTests(SimpleModelTestMixin, TestCase):
+    """ Client set referer header when calling tasks
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """ Creates rpc-client object
+        """
+        super(SetRefererTests, cls).setUpClass()
+        cls.rpc_client = Client()
+        cls.task_name = utils.FILTER_TASK_NAME
+
+    def testSetRefererHeader(self):
+        """ Method `prepare_task` set referer header
+        """
+        signature = self.rpc_client.prepare_task(self.task_name, None, None)
+        self.assertEqual(
+            signature.options["headers"],
+            {"referer": "@".join([config.RPC_CLIENT_NAME, socket.gethostname()])})


### PR DESCRIPTION
Идея следующая: при вызове задач ставим им заголовок referer. В итоге сервер знает какой именно клиент вызвал эту задачу. 
Белке это нужно для более детального отслеживания мест, из которых прилетают изменения